### PR TITLE
Added queuing for streams, allowing for custom configs for each pass

### DIFF
--- a/src/Components/Modules/Mvm.cpp
+++ b/src/Components/Modules/Mvm.cpp
@@ -532,6 +532,12 @@ namespace Components
 			/* default	*/ false,
 			/* flags	*/ Game::dvar_flags::none);
 
+		Dvars::cl_avidemo_streams_queueEnable = Game::Dvar_RegisterBool(
+			/* name		*/ "cl_avidemo_streams_queueEnable",
+			/* desc		*/ "enable streams queueing",
+			/* default	*/ false,
+			/* flags	*/ Game::dvar_flags::saved);
+
 
 		// mvm hooks at the next op
 		Utils::Hook(0x46C8EB, CL_RunOncePerClientFrame_stub, HOOK_JUMP).install()->quick();

--- a/src/Components/Modules/_Common.cpp
+++ b/src/Components/Modules/_Common.cpp
@@ -22,6 +22,12 @@ namespace Components
 		{
 			RB_ShaderOverlays::Register_StringDvars();
 		}
+
+		Dvars::cl_avidemo_streams_queue = Game::Dvar_RegisterString(
+			/* name		*/ "cl_avidemo_streams_queue",
+			/* desc		*/ "current queue of configs that should be taken into account when using streams",
+			/* default	*/ "",
+			/* flags	*/ Game::dvar_flags::saved);
 	}
 
 	void ForceDvarsOnInit()

--- a/src/Game/Dvars.cpp
+++ b/src/Game/Dvars.cpp
@@ -8,6 +8,8 @@ namespace Dvars
 	Game::dvar_s* cl_avidemo_streams_viewmodel = nullptr;
 	Game::dvar_s* cl_avidemo_streams_depth = nullptr;
 	Game::dvar_s* cl_avidemo_streams_hud = nullptr;
+	Game::dvar_s* cl_avidemo_streams_queue = nullptr;
+	Game::dvar_s* cl_avidemo_streams_queueEnable = nullptr;
 	Game::dvar_s* cl_pause_demo = nullptr;
 	Game::dvar_s* load_iw3mvm = nullptr;
 

--- a/src/Game/Dvars.hpp
+++ b/src/Game/Dvars.hpp
@@ -8,6 +8,8 @@ namespace Dvars
 	extern Game::dvar_s* cl_avidemo_streams_viewmodel;
 	extern Game::dvar_s* cl_avidemo_streams_depth;
 	extern Game::dvar_s* cl_avidemo_streams_hud;
+	extern Game::dvar_s* cl_avidemo_streams_queue;
+	extern Game::dvar_s* cl_avidemo_streams_queueEnable;
 	extern Game::dvar_s* cl_pause_demo;
 	extern Game::dvar_s* load_iw3mvm;
 


### PR DESCRIPTION
Config queuing allows for customizable streams, where each config counts as a render-pass for each frame to be rendered

- `cl_avidemo_streams_queueEnable "1"` Toggles the usability
- `cl_avidemo_streams_queue "config1 config2 config3 ..."` sets the preferred renderpasses, executed from the `main` directory