### PR TITLE
fix: resolve issue with dvarFloatList and dvarStrList on menu export

### DIFF
--- a/src/components/modules/menu_export.cpp
+++ b/src/components/modules/menu_export.cpp
@@ -387,13 +387,13 @@ namespace components
 
 			for (int i = 0; i < itemDef.typeData.multi->count; i++) 
 			{
-				if (itemDef.typeData.multi->strDef == 1) 
+				if (itemDef.typeData.multi->strDef == 1)
 				{
-					menu_file_ << itemDef.typeData.multi->dvarList[i] << " " << itemDef.typeData.multi->dvarStr[i] << " ";
+					menu_file_ << '"' << itemDef.typeData.multi->dvarList[i] << '"' << ", " << '"' << itemDef.typeData.multi->dvarStr[i] << '"' << "; ";
 				}
-				else 
+				else
 				{
-					menu_file_ << itemDef.typeData.multi->dvarList[i] << " " << itemDef.typeData.multi->dvarValue[i] << " ";
+					menu_file_ << '"' << itemDef.typeData.multi->dvarList[i] << '"' << " " << itemDef.typeData.multi->dvarValue[i] << " ";
 				}
 			}
 


### PR DESCRIPTION
menu_export currently exports 'dvarFloatList' and 'dvarStrList' lines incorrectly.

This commit resolves the issue.

Examples;

dvarFloatList - createserver.menu

current behaviour:
![image](https://user-images.githubusercontent.com/13552261/234539156-3c2405c7-1b76-4a37-a62c-23be9a4bc0bb.png)
![image](https://user-images.githubusercontent.com/13552261/234539190-b56badf8-7c6f-4726-877e-abfc201901ff.png)


behaviour with this commit:
![image](https://user-images.githubusercontent.com/13552261/234539319-0d234319-4041-4d32-a97d-99af2db3369f.png)
![image](https://user-images.githubusercontent.com/13552261/234539335-bc280406-6759-4bfd-bc91-e6acb4b88f9f.png)


dvarStrList - options_sound.menu

current behaviour:
![image](https://user-images.githubusercontent.com/13552261/234540071-b65085a5-2c5d-465a-92f8-70dc2e2acc9f.png)

behaviour with this commit:
![image](https://user-images.githubusercontent.com/13552261/234540145-b58a7c5a-deb3-4304-95ff-0ac7ab5b06fa.png)
